### PR TITLE
:sparkles: feat: you can now select a service in the sidebar

### DIFF
--- a/src/opendms/frontend/src/components/service-select/service-select.stories.tsx
+++ b/src/opendms/frontend/src/components/service-select/service-select.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  reactRouterParameters,
+  withRouter,
+} from "storybook-addon-remix-react-router";
+import { userEvent } from "storybook/test";
+import { ServiceSelect } from "~/components/service-select/service-select.tsx";
+
+import { withCSRF } from "../../../.storybook/decorators.tsx";
+
+const meta: Meta<typeof ServiceSelect> = {
+  title: "Routes/ServiceSelect",
+  component: ServiceSelect,
+  decorators: [withRouter, withCSRF],
+  args: {
+    options: [
+      {
+        label: "Option 1",
+        value: "option 1",
+      },
+      {
+        label: "Option 2",
+        value: "option 2",
+      },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ServiceSelect>;
+
+export const SelectService: Story = {
+  play: async ({ canvasElement }) => {
+    const select = canvasElement.querySelector("select") as HTMLSelectElement;
+    await userEvent.click(select);
+
+    const dropdown = canvasElement.querySelector(
+      ".mykn-select__options",
+    ) as HTMLDivElement;
+
+    const firstOption = dropdown.querySelector(
+      ".mykn-option",
+    ) as HTMLDivElement;
+
+    await userEvent.click(firstOption);
+  },
+};

--- a/src/opendms/frontend/src/components/service-select/service-select.tsx
+++ b/src/opendms/frontend/src/components/service-select/service-select.tsx
@@ -1,0 +1,31 @@
+import { type Option, Select } from "@maykin-ui/admin-ui";
+import { type FC } from "react";
+import { useSearchParams } from "react-router";
+
+const SEARCH_PARAM_NAME = "service-select";
+
+interface ServiceSelectProps {
+  options: Option[];
+}
+export const ServiceSelect: FC<ServiceSelectProps> = ({ options = [] }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedService = searchParams.get(SEARCH_PARAM_NAME);
+
+  const setSelectedService = (value: string) => {
+    setSearchParams((searchParams) => {
+      searchParams.set(SEARCH_PARAM_NAME, value);
+      return searchParams;
+    });
+  };
+
+  return (
+    <Select
+      options={options}
+      placeholder="Selceteer Service"
+      value={selectedService}
+      variant="secondary"
+      onChange={({ target }) => setSelectedService(target.value)}
+    />
+  );
+};

--- a/src/opendms/frontend/src/root.tsx
+++ b/src/opendms/frontend/src/root.tsx
@@ -4,11 +4,14 @@ import {
   H2,
   Hr,
   Logo,
+  type Option,
   Outline,
 } from "@maykin-ui/admin-ui";
 import "@maykin-ui/admin-ui/style";
 import "@maykin-ui/admin-ui/style/themes/blue-suede-shoes.css";
-import { Outlet, useNavigate } from "react-router";
+import type { FC } from "react";
+import { Outlet, useLoaderData, useNavigate } from "react-router";
+import { ServiceSelect } from "~/components/service-select/service-select.tsx";
 import { apiRequest } from "~/lib";
 
 /**
@@ -28,13 +31,32 @@ export const Layout = () => {
   );
 };
 
+// TODO: From backend?
+type authenticatedLayoutLoaderData = {
+  serviceOptions: Option[];
+};
+
+export async function authenticatedLayoutLoader() {
+  // TODO: Refine once API is clear, draft for now
+  const response = await apiRequest<Response>("/api/v1/service/options", "GET");
+
+  if (!response.ok) {
+    throw new Response("Failed to load options", { status: response.status });
+  }
+
+  const serviceOptions: authenticatedLayoutLoaderData["serviceOptions"] =
+    await response.json();
+  return { serviceOptions };
+}
+
 /**
  * Represents a layout component tailored for authenticated users.
  *
  * @returns {JSX.Element} The rendered layout structure for the application.
  */
-export const AuthenticatedLayout = () => {
+export const AuthenticatedLayout: FC = () => {
   const navigate = useNavigate();
+  const { serviceOptions } = useLoaderData() as authenticatedLayoutLoaderData;
 
   const handleLogout = async () => {
     await apiRequest("/api/v1/accounts/logout");
@@ -56,6 +78,7 @@ export const AuthenticatedLayout = () => {
       sidebarItems={[
         <H2 key={"sidebar-h2"}>Open DMS</H2>,
         <Hr key={"sidebar-hr"} />,
+        <ServiceSelect key="service-select" options={serviceOptions} />,
       ]}
     >
       <ConfigContext.Provider

--- a/src/opendms/frontend/src/routes.ts
+++ b/src/opendms/frontend/src/routes.ts
@@ -1,8 +1,12 @@
 import { createBrowserRouter } from "react-router";
+import { authMiddleware } from "~/middleware/auth.ts";
 import { Login, loginAction } from "~/routes/index.ts";
 
-import { authMiddleware } from "./middleware/auth.ts";
-import { AuthenticatedLayout, Layout } from "./root.tsx";
+import {
+  AuthenticatedLayout,
+  Layout,
+  authenticatedLayoutLoader,
+} from "./root.tsx";
 
 /**
  * Built in "Data Mode" style using createBrowserRouter. https://reactrouter.com/start/modes#data
@@ -23,6 +27,7 @@ export const routes = createBrowserRouter([
   {
     Component: AuthenticatedLayout,
     middleware: [authMiddleware],
+    loader: authenticatedLayoutLoader,
     children: [
       {
         index: true,


### PR DESCRIPTION
- I made the conscious choice to make the API call in the loader for all sub-routes for authenticated routes, as we don't want to access a page without the service's being loaded in.

But there is an argument to be made that whenever we already have selected a service (and we want it pre-selected for the future) we don't need to necessarily wait on the service choices as we will not use them since our service is already chosen.

If this is desirable, we might want to make the call to the API for the services client-sided in an async select (this way it doesn't block page loading).

- For now I made the easiest/quickest solution, but we need to take this into account
