### PR TITLE
:sparkles: feat: development server now works with CORS

### DIFF
--- a/src/opendms/frontend/src/lib/api.ts
+++ b/src/opendms/frontend/src/lib/api.ts
@@ -64,7 +64,8 @@ const csrfClientMiddleware: Middleware = {
  * and adheres to the defined paths structure for endpoint typing and safety.
  */
 export const apiClient = createClient<paths>({
-  baseUrl: window.location.origin,
+  // This is needed to make sure on development our proxy works, whilst in production we do want the location's URL
+  baseUrl: import.meta.env.DEV ? "" : window.location.origin,
 });
 apiClient.use(contentTypeJSONMiddleware);
 apiClient.use(csrfClientMiddleware);

--- a/src/opendms/frontend/vite.config.ts
+++ b/src/opendms/frontend/vite.config.ts
@@ -13,7 +13,7 @@ const dirname =
     : path.dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   build: {
     assetsDir: "static", // Make sure Django can pick up assets.
   },
@@ -28,6 +28,18 @@ export default defineConfig({
     alias: {
       "~": path.resolve(__dirname, "src"),
     },
+  },
+  // For development, this runs a proxy upon `/api/*` that forwards the URL to `http://localhost:8000/api/*` for CSRF functionality
+  server: {
+    ...(mode === "development" && {
+      proxy: {
+        "/api": {
+          target: "http://localhost:8000",
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    }),
   },
   test: {
     projects: [
@@ -57,4 +69,4 @@ export default defineConfig({
       },
     ],
   },
-});
+}));


### PR DESCRIPTION
These changes proxy the local frontend URL (localhost:5173) to the backend URL (localhost:8000) to have a seamless experience when developing in the frontend.

This avoids having to run from the backend with `npm run build` in the frontend at every change.