### PR TITLE
feat: show documents not linked to a case (onbekend documents)

### DIFF
--- a/src/opendms/api/clients/documenten.py
+++ b/src/opendms/api/clients/documenten.py
@@ -129,6 +129,35 @@ class DocumentClient(HttpRequestMixin, NLXClient):
         results = [self._map_document({**record}) for record in data.get("results", [])]
         return DocumentsPaginatedResponse(count=data.get("count", 0), results=results)
 
+    def get_unlinked_documents_by_iot(
+        self,
+        iot_url: str,
+        oio_client: "ObjectInformatieObjectClient",
+        params: dict | None = None,
+    ) -> DocumentsPaginatedResponse:
+        """
+        Return documents of a given informatieobjecttype that have no zaak OIO link.
+        Fetches all pages of EIOs for the IOT, filters against the set of zaak-linked
+        document URLs from the OIO endpoint, and re-paginates in this layer.
+        """
+        params = params or {}
+        page = int(params.get("page", 1))
+        page_size = int(params.get("pageSize", 20))
+
+        linked_urls = oio_client.get_all_zaak_linked_urls()
+
+        first_page = self.make_request(
+            self.endpoint,
+            params={"informatieobjecttype": iot_url},
+        )
+        all_records = list(pagination_helper(self, first_page))
+        unlinked = [r for r in all_records if r["url"] not in linked_urls]
+        mapped = [self._map_document(r) for r in unlinked]
+
+        start = (page - 1) * page_size
+        end = start + page_size
+        return DocumentsPaginatedResponse(count=len(mapped), results=mapped[start:end])
+
     @staticmethod
     def _map_document(record: dict) -> DocumentType:
         return DocumentType(
@@ -174,6 +203,18 @@ class ObjectInformatieObjectClient(HttpRequestMixin, NLXClient):
             headers=CRS_HEADERS,
         )
         return data
+
+    def get_all_zaak_linked_urls(self) -> set[str]:
+        """
+        Return the set of informatieobject URLs that are linked to a zaak via an OIO.
+        OIOs are returned as a flat list (not paginated) by the DRC API.
+        """
+        data = self.make_request(self.endpoint, headers=CRS_HEADERS)
+        return {
+            item["informatieobject"]
+            for item in data
+            if item.get("objectType") == "zaak"
+        }
 
 
 def get_oio_client(service: Service) -> ObjectInformatieObjectClient:

--- a/src/opendms/api/clients/documenten.py
+++ b/src/opendms/api/clients/documenten.py
@@ -66,10 +66,27 @@ class DocumentClient(HttpRequestMixin, NLXClient):
         extension = guess_extension_by_response(response)
         fullname = f"{name}{extension}"
 
+        # Hop-by-hop headers must be stripped before forwarding — wsgiref rejects them.
+        hop_by_hop = {
+            "connection",
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-authorization",
+            "te",
+            "trailers",
+            "transfer-encoding",
+            "upgrade",
+        }
+        safe_headers = {
+            k: v
+            for k, v in response.headers.items()
+            if k.lower() not in hop_by_hop
+        }
+
         return HttpResponse(
             response.content,
             headers={
-                **response.headers,
+                **safe_headers,
                 "Content-Disposition": f'attachment; filename="{fullname}"',
                 "File-Name": fullname,
                 "File-Extension": extension,

--- a/src/opendms/api/clients/zaaktypen.py
+++ b/src/opendms/api/clients/zaaktypen.py
@@ -6,7 +6,12 @@ from zgw_consumers.client import build_client
 from zgw_consumers.models import Service
 from zgw_consumers.nlx import NLXClient
 
-from ..typing import ZaakType, ZaakTypenPaginatedResponse
+from ..typing import (
+    InformatieObjectType,
+    InformatieObjectTypenPaginatedResponse,
+    ZaakType,
+    ZaakTypenPaginatedResponse,
+)
 from ..utils.mixins import HttpRequestMixin
 from ..utils.validators import extract_uuid
 
@@ -41,6 +46,35 @@ class ZaakTypeClient(HttpRequestMixin, NLXClient):
             omschrijving=record["omschrijving"],
             beginGeldigheid=record["beginGeldigheid"],
             eindeGeldigheid=record["eindeGeldigheid"],
+        )
+
+    def get_paginated_informatieobjecttypen(
+        self,
+        params: dict | None = None,
+    ) -> InformatieObjectTypenPaginatedResponse:
+        params = params or {}
+        data = self.make_request("informatieobjecttypen", params)
+        results = sorted(
+            [self._map_iot(record) for record in data.get("results", [])],
+            key=lambda iot: iot["omschrijving"].lower(),
+        )
+        return InformatieObjectTypenPaginatedResponse(count=data["count"], results=results)
+
+    def get_informatieobjecttype_by_uuid(self, uuid: str) -> InformatieObjectType:
+        data = self.make_request(f"informatieobjecttypen/{uuid}")
+        return self._map_iot(data)
+
+    @staticmethod
+    def _map_iot(record: dict) -> InformatieObjectType:
+        return InformatieObjectType(
+            uuid=extract_uuid(record["url"]),
+            url=record["url"],
+            catalogus=record["catalogus"],
+            omschrijving=record["omschrijving"],
+            vertrouwelijkheidaanduiding=record.get("vertrouwelijkheidaanduiding"),
+            beginGeldigheid=record["beginGeldigheid"],
+            eindeGeldigheid=record["eindeGeldigheid"],
+            concept=record["concept"],
         )
 
     def get_paginated_cached_items(

--- a/src/opendms/api/openapi.yaml
+++ b/src/opendms/api/openapi.yaml
@@ -13,9 +13,9 @@ info:
     name: EUPL 1.2
     url: https://opensource.org/licenses/EUPL-1.2
 paths:
-  /api/v1/accounts/login:
+  /accounts/login:
     post:
-      operationId: apiV1AccountsLoginCreate
+      operationId: accountsLoginCreate
       description: Authenticates the user, returns whoami details on successful login.
       summary: login
       tags:
@@ -65,9 +65,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
           description: ''
-  /api/v1/accounts/logout:
+  /accounts/logout:
     get:
-      operationId: apiV1AccountsLogoutRetrieve
+      operationId: accountsLogoutRetrieve
       description: Remove the authenticated user's ID from the request and flush their
         session data.
       summary: logout
@@ -84,9 +84,9 @@ paths:
               description: 'Geeft een specifieke API-versie aan in de context van
                 een specifieke aanroep. Voorbeeld: 1.2.1.'
           description: No response body
-  /api/v1/accounts/whoami:
+  /accounts/whoami:
     get:
-      operationId: apiV1AccountsWhoamiRetrieve
+      operationId: accountsWhoamiRetrieve
       description: Returns the current logged in user.
       summary: whoami
       tags:
@@ -106,11 +106,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/WhoAmI'
           description: ''
-  /api/v1/search:
+  /search:
     post:
       operationId: search
       description: Search the document records.
-      summary: Search
+      summary: Zoeken
       tags:
       - search
       requestBody:
@@ -133,14 +133,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/SearchResponse'
           description: ''
-  /api/v1/services:
+  /services:
     get:
-      operationId: apiV1ServicesList
+      operationId: servicesList
       parameters:
       - name: page
         required: false
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         schema:
           type: integer
       - name: pageSize
@@ -157,7 +157,7 @@ paths:
         schema:
           type: string
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -173,16 +173,218 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedServiceList'
           description: ''
-  /api/v1/services/{serviceSlug}/zaaktypen:
+  /services/{serviceSlug}/informatieobjecttypen:
     get:
-      operationId: apiV1ServicesZaaktypenList
+      operationId: servicesInformatieobjecttypenList
+      description: Exposes InformatieObjectTypen from /services/<zgw-service>/informatieobjecttypen
+      summary: informatieobjecttypenList
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: Een pagina binnen de gepagineerde set resultaten.
+        schema:
+          type: integer
+      - name: pageSize
+        required: false
+        in: query
+        description: 'Het aantal resultaten terug te geven per pagina. (default: 100,
+          maximum: 500).'
+        schema:
+          type: integer
+      - in: path
+        name: serviceSlug
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedInformatieObjectTypeList'
+          description: ''
+  /services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents:
+    get:
+      operationId: servicesInformatieobjecttypenDocumentsList
+      description: |-
+        Exposes Documents not linked to any Zaak, grouped by InformatieObjectType.
+        Route: /services/<serviceSlug>/informatieobjecttypen/<iotUuid>/documents
+      summary: onbekendDocumentsList
+      parameters:
+      - in: path
+        name: informatieobjecttypenIotUuid
+        schema:
+          type: string
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: Een pagina binnen de gepagineerde set resultaten.
+        schema:
+          type: integer
+      - name: pageSize
+        required: false
+        in: query
+        description: 'Het aantal resultaten terug te geven per pagina. (default: 100,
+          maximum: 500).'
+        schema:
+          type: integer
+      - in: path
+        name: serviceSlug
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedDocumentList'
+          description: ''
+  /services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents/{documentUuid}:
+    get:
+      operationId: servicesInformatieobjecttypenDocumentsRetrieve
+      description: |-
+        Exposes Documents not linked to any Zaak, grouped by InformatieObjectType.
+        Route: /services/<serviceSlug>/informatieobjecttypen/<iotUuid>/documents
+      summary: onbekendDocumentsRetrieve
+      parameters:
+      - in: path
+        name: documentUuid
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: informatieobjecttypenIotUuid
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: serviceSlug
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+          description: ''
+  /services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents/{documentUuid}/download:
+    get:
+      operationId: onbekendDocumentDownload
+      description: Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT
+        (onbekend/niet gekoppeld).
+      summary: onbekendDocumentsDownload
+      parameters:
+      - in: path
+        name: documentUuid
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: informatieobjecttypenIotUuid
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: serviceSlug
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: De binaire bestandsinhoud
+  /services/{serviceSlug}/informatieobjecttypen/{iotUuid}:
+    get:
+      operationId: servicesInformatieobjecttypenRetrieve
+      description: Exposes InformatieObjectTypen from /services/<zgw-service>/informatieobjecttypen
+      summary: informatieobjecttypenRetrieve
+      parameters:
+      - in: path
+        name: iotUuid
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: serviceSlug
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InformatieObjectType'
+          description: ''
+  /services/{serviceSlug}/zaaktypen:
+    get:
+      operationId: servicesZaaktypenList
       description: Exposes Zaaktypen from /services/<zgw-service>/zaaktypen
       summary: zaaktypenList
       parameters:
       - name: page
         required: false
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         schema:
           type: integer
       - name: pageSize
@@ -204,7 +406,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -220,9 +422,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedZaakTypeList'
           description: ''
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypeUuid}:
+  /services/{serviceSlug}/zaaktypen/{zaaktypeUuid}:
     get:
-      operationId: apiV1ServicesZaaktypenRetrieve
+      operationId: servicesZaaktypenRetrieve
       description: Exposes Zaaktypen from /services/<zgw-service>/zaaktypen
       summary: zaaktypenRetrieve
       parameters:
@@ -237,7 +439,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -253,9 +455,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ZaakType'
           description: ''
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken:
+  /services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken:
     get:
-      operationId: apiV1ServicesZaaktypenZakenList
+      operationId: servicesZaaktypenZakenList
       description: Exposes Zaak from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken
       summary: zakenList
       parameters:
@@ -274,7 +476,7 @@ paths:
       - name: page
         required: false
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         schema:
           type: integer
       - name: pageSize
@@ -301,7 +503,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -317,9 +519,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedZaakList'
           description: ''
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zaakUuid}:
+  /services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zaakUuid}:
     get:
-      operationId: apiV1ServicesZaaktypenZakenRetrieve
+      operationId: servicesZaaktypenZakenRetrieve
       description: Exposes Zaak from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken
       summary: zakenRetrieve
       parameters:
@@ -339,7 +541,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -355,16 +557,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/Zaak'
           description: ''
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents:
+  /services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents:
     get:
-      operationId: apiV1ServicesZaaktypenZakenDocumentsList
+      operationId: servicesZaaktypenZakenDocumentsList
       description: Exposes Documents from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken/<zaak>/documents
       summary: documentsList
       parameters:
       - name: page
         required: false
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         schema:
           type: integer
       - name: pageSize
@@ -390,7 +592,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -406,9 +608,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedDocumentList'
           description: ''
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}:
+  /services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}:
     get:
-      operationId: apiV1ServicesZaaktypenZakenDocumentsRetrieve
+      operationId: servicesZaaktypenZakenDocumentsRetrieve
       description: Exposes Documents from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken/<zaak>/documents
       summary: documentsRetrieve
       parameters:
@@ -433,7 +635,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -449,7 +651,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Document'
           description: ''
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/download:
+  /services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/download:
     get:
       operationId: documentDownload
       description: Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT.
@@ -476,7 +678,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -493,7 +695,7 @@ paths:
                 type: string
                 format: binary
           description: De binaire bestandsinhoud
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/edit:
+  /services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/edit:
     get:
       operationId: documentEdit
       description: Een document met binaire gegevens bewerken op OneDrive
@@ -525,7 +727,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -553,7 +755,7 @@ paths:
               description: 'Geeft een specifieke API-versie aan in de context van
                 een specifieke aanroep. Voorbeeld: 1.2.1.'
           description: Empty body, document is locked
-  /api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/upload:
+  /services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/upload:
     get:
       operationId: documentUpload
       description: Een nieuwe versie van een document uploaden naar OpenZaak
@@ -580,7 +782,7 @@ paths:
           type: string
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -596,9 +798,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Document'
           description: ''
-  /api/v1/services/{slug}:
+  /services/{slug}:
     get:
-      operationId: apiV1ServicesRetrieve
+      operationId: servicesRetrieve
       parameters:
       - in: path
         name: slug
@@ -609,7 +811,7 @@ paths:
             useful for cross-instance import/export.
         required: true
       tags:
-      - api
+      - services
       security:
       - cookieAuth: []
       responses:
@@ -625,77 +827,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Service'
           description: ''
-  /oidc/callback/:
-    get:
-      operationId: oidcCallbackRetrieve
-      description: Callback endpoint voor Microsoft OAuth authenticatie.
-      summary: Microsoft authentication callback
-      tags:
-      - oidc
-      security:
-      - cookieAuth: []
-      responses:
-        '302':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          description: Redirect naar de oorspronkelijke URL na succesvolle authenticatie
-        '400':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          description: Invalid callback of fout tijdens authenticatie
-        '401':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          description: Authenticatie mislukt (geen access token)
-  /webhook:
-    post:
-      operationId: webhookCreate
-      description: Endpoint webhook che riceve notifiche dal backend document_edit.
-      summary: Webhook callback
-      tags:
-      - webhook
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: {}
-      security:
-      - cookieAuth: []
-      - {}
-      responses:
-        '200':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            text/plain:
-              schema:
-                type: string
-          description: Webhook verwerkt
-        '400':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          description: Ongeldige payload
 components:
   schemas:
     Auth:
@@ -704,9 +835,11 @@ components:
         username:
           type: string
           writeOnly: true
+          title: Gebruikersnaam
         password:
           type: string
           writeOnly: true
+          title: Wachtwoord
       required:
       - password
       - username
@@ -1045,6 +1178,49 @@ components:
       - instance
       - status
       - title
+    InformatieObjectType:
+      type: object
+      properties:
+        uuid:
+          type: string
+          description: Unieke resource identifier (UUID4)
+        url:
+          type: string
+          format: uri
+          description: URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+        catalogus:
+          type: string
+          format: uri
+          description: URL-referentie naar de CATALOGUS waartoe dit INFORMATIEOBJECTTYPE
+            behoort.
+        omschrijving:
+          type: string
+          description: Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.
+        vertrouwelijkheidaanduiding:
+          type: string
+          nullable: true
+          description: Aanduiding van de mate waarin informatieobjecten van dit type
+            voor de openbaarheid bestemd zijn.
+        beginGeldigheid:
+          type: string
+          format: date
+          nullable: true
+          description: De datum waarop het is ontstaan.
+        eindeGeldigheid:
+          type: string
+          format: date
+          nullable: true
+          description: De datum waarop het is opgeheven.
+        concept:
+          type: boolean
+          description: Geeft aan of het object een concept betreft.
+      required:
+      - catalogus
+      - concept
+      - omschrijving
+      - url
+      - uuid
     PaginatedDocumentList:
       type: object
       required:
@@ -1058,6 +1234,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Document'
+    PaginatedInformatieObjectTypeList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/InformatieObjectType'
     PaginatedServiceList:
       type: object
       required:
@@ -1226,20 +1415,23 @@ components:
           title: ID
         username:
           type: string
-          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
-            only.
+          title: Gebruikersnaam
+          description: Vereist. 150 tekens of minder. Alleen letters, cijfers en de
+            tekens @/,/+/-/_ zijn toegestaan.
           pattern: ^[\w.@+-]+$
           maxLength: 150
         firstName:
           type: string
+          title: Voornaam
           maxLength: 255
         lastName:
           type: string
+          title: Achternaam
           maxLength: 255
         email:
           type: string
           format: email
-          title: Email address
+          title: E-mailadres
           maxLength: 254
       required:
       - pk

--- a/src/opendms/api/serializers.py
+++ b/src/opendms/api/serializers.py
@@ -53,6 +53,41 @@ class ZaakTypeSerializer(serializers.Serializer):
     )
 
 
+class InformatieObjectTypeSerializer(serializers.Serializer):
+    uuid = serializers.CharField(
+        help_text=_("Unieke resource identifier (UUID4)"),
+    )
+    url = serializers.URLField(
+        help_text=_(
+            "URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object."
+        ),
+    )
+    catalogus = serializers.URLField(
+        help_text=_("URL-referentie naar de CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort."),
+    )
+    omschrijving = serializers.CharField(
+        help_text=_("Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE."),
+    )
+    vertrouwelijkheidaanduiding = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text=_("Aanduiding van de mate waarin informatieobjecten van dit type voor de openbaarheid bestemd zijn."),
+    )
+    beginGeldigheid = serializers.DateField(
+        allow_null=True,
+        required=False,
+        help_text=_("De datum waarop het is ontstaan."),
+    )
+    eindeGeldigheid = serializers.DateField(
+        allow_null=True,
+        required=False,
+        help_text=_("De datum waarop het is opgeheven."),
+    )
+    concept = serializers.BooleanField(
+        help_text=_("Geeft aan of het object een concept betreft."),
+    )
+
+
 class ZaakSerializer(serializers.Serializer):
     uuid = serializers.UUIDField(
         help_text=_(

--- a/src/opendms/api/typing.py
+++ b/src/opendms/api/typing.py
@@ -97,6 +97,17 @@ class ESDocumentType(TypedDict):
     zaak_referenties: list[ESZaak]
 
 
+class InformatieObjectType(TypedDict):
+    uuid: str
+    url: str
+    catalogus: str
+    omschrijving: str
+    vertrouwelijkheidaanduiding: str | None
+    beginGeldigheid: date | None
+    eindeGeldigheid: date | None
+    concept: bool
+
+
 class ObjectInformatieObjectType(TypedDict):
     url: str
     informatieobject: str
@@ -117,3 +128,4 @@ ZaakTypenPaginatedResponse = PaginatedResponse[ZaakType]
 ZakenPaginatedResponse = PaginatedResponse[Zaak]
 DocumentsPaginatedResponse = PaginatedResponse[DocumentType]
 ESDocumentsPaginatedResponse = PaginatedResponse[ESDocumentType]
+InformatieObjectTypenPaginatedResponse = PaginatedResponse[InformatieObjectType]

--- a/src/opendms/api/urls.py
+++ b/src/opendms/api/urls.py
@@ -7,6 +7,8 @@ from opendms.api.utils.views import SpectacularJSONAPIView, SpectacularYAMLAPIVi
 
 from .viewsets import (
     DocumentViewSet,
+    InformatieObjectTypeViewSet,
+    OnbekendDocumentViewSet,
     SearchView,
     ServiceViewSet,
     ZaakTypeViewSet,
@@ -51,6 +53,28 @@ documents_router.register(
     basename="documents",
 )
 
+informatieobjecttypen_router = routers.NestedSimpleRouter(
+    router,
+    r"services",
+    lookup="service",
+)
+informatieobjecttypen_router.register(
+    r"informatieobjecttypen",
+    InformatieObjectTypeViewSet,
+    basename="informatieobjecttypen",
+)
+
+onbekend_documents_router = routers.NestedSimpleRouter(
+    informatieobjecttypen_router,
+    r"informatieobjecttypen",
+    lookup="informatieobjecttypen",
+)
+onbekend_documents_router.register(
+    r"documents",
+    OnbekendDocumentViewSet,
+    basename="onbekend-documents",
+)
+
 urlpatterns = [
     re_path(
         r"^v(?P<version>\d+)/",
@@ -60,6 +84,8 @@ urlpatterns = [
                 re_path(r"^", include(zaaktypen_router.urls)),
                 re_path(r"^", include(zaken_router.urls)),
                 re_path(r"^", include(documents_router.urls)),
+                re_path(r"^", include(informatieobjecttypen_router.urls)),
+                re_path(r"^", include(onbekend_documents_router.urls)),
                 path(
                     "accounts/",
                     include("opendms.accounts.api.urls", namespace="accounts"),

--- a/src/opendms/api/utils/schema.py
+++ b/src/opendms/api/utils/schema.py
@@ -59,6 +59,18 @@ ZAKEN_ZAAK_UUID_PARAM = OpenApiParameter(
     location=OpenApiParameter.PATH,
     required=True,
 )
+IOT_PARAM = OpenApiParameter(
+    name="iot_uuid",
+    type=OpenApiTypes.STR,
+    location=OpenApiParameter.PATH,
+    required=True,
+)
+INFORMATIEOBJECTTYPEN_IOT_UUID_PARAM = OpenApiParameter(
+    name="informatieobjecttypen_iot_uuid",
+    type=OpenApiTypes.STR,
+    location=OpenApiParameter.PATH,
+    required=True,
+)
 
 OpenApiTypeLiteral = Literal[
     OpenApiTypes.STR,

--- a/src/opendms/api/viewsets.py
+++ b/src/opendms/api/viewsets.py
@@ -32,10 +32,16 @@ from opendms.doc_edit.models import BaseDriveDocument
 from opendms.search_index.client import get_elasticsearch_client
 
 from ..doc_edit.utils import is_within_threshold
-from .clients import get_documenten_client, get_zaaktypen_client, get_zaken_client
+from .clients import (
+    get_documenten_client,
+    get_oio_client,
+    get_zaaktypen_client,
+    get_zaken_client,
+)
 from .models import ZGWApiGroupConfig
 from .serializers import (
     DocumentSerializer,
+    InformatieObjectTypeSerializer,
     SearchResponseSerializer,
     SearchSerializer,
     ServiceSerializer,
@@ -45,6 +51,8 @@ from .serializers import (
 from .typing import (
     DocumentsPaginatedResponse,
     DocumentType,
+    InformatieObjectType,
+    InformatieObjectTypenPaginatedResponse,
     SearchParameters,
     Zaak,
     ZaakType,
@@ -55,6 +63,8 @@ from .utils.mixins import ReadOnlyViewSetMixin
 from .utils.pagination import CountedPagination
 from .utils.schema import (
     DOCUMENT_PARAM,
+    INFORMATIEOBJECTTYPEN_IOT_UUID_PARAM,
+    IOT_PARAM,
     QUERY_PARAM,
     QUERY_PARAM_FIELD,
     SERVICE_PARAM,
@@ -619,3 +629,98 @@ class DocumentViewSet(ReadOnlyViewSetMixin, viewsets.ViewSet):
         callback_url = request.build_absolute_uri(reverse("ms_auth_callback"))
         request.session["origin_url"] = request.build_absolute_uri()
         return document_edit_backend.authenticate(request, redirect_url=callback_url)
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary="informatieobjecttypenList",
+        parameters=[SERVICE_PARAM],
+    ),
+    retrieve=extend_schema(
+        summary="informatieobjecttypenRetrieve",
+        parameters=[SERVICE_PARAM, IOT_PARAM],
+    ),
+)
+class InformatieObjectTypeViewSet(ReadOnlyViewSetMixin, viewsets.ViewSet):
+    """
+    Exposes InformatieObjectTypen from /services/<zgw-service>/informatieobjecttypen
+    """
+
+    serializer_class = InformatieObjectTypeSerializer
+    pagination_class = CountedPagination
+    lookup_field = "iot_uuid"
+    queryset = None
+
+    def get_object(self) -> InformatieObjectType:
+        uuid = self.kwargs.get(self.lookup_field)
+        with get_zaaktypen_client(self.zgw_group.ztc_service) as client:
+            return client.get_informatieobjecttype_by_uuid(uuid)
+
+    def get_paginated_queryset(self, params: dict) -> InformatieObjectTypenPaginatedResponse:
+        with get_zaaktypen_client(self.zgw_group.ztc_service) as client:
+            return client.get_paginated_informatieobjecttypen(params)
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary="onbekendDocumentsList",
+        parameters=[SERVICE_PARAM, INFORMATIEOBJECTTYPEN_IOT_UUID_PARAM],
+    ),
+    retrieve=extend_schema(
+        summary="onbekendDocumentsRetrieve",
+        parameters=[SERVICE_PARAM, INFORMATIEOBJECTTYPEN_IOT_UUID_PARAM, DOCUMENT_PARAM],
+    ),
+)
+class OnbekendDocumentViewSet(ReadOnlyViewSetMixin, viewsets.ViewSet):
+    """
+    Exposes Documents not linked to any Zaak, grouped by InformatieObjectType.
+    Route: /services/<serviceSlug>/informatieobjecttypen/<iotUuid>/documents
+    """
+
+    serializer_class = DocumentSerializer
+    pagination_class = CountedPagination
+    lookup_field = "document_uuid"
+    parent_lookup_field = "informatieobjecttypen_iot_uuid"
+    queryset = None
+    _object = None
+
+    @property
+    def iot_url(self) -> str:
+        iot_uuid = self.kwargs.get(self.parent_lookup_field)
+        with get_zaaktypen_client(self.zgw_group.ztc_service) as client:
+            iot = client.get_informatieobjecttype_by_uuid(iot_uuid)
+            return iot["url"]
+
+    def get_object(self) -> DocumentType | None:
+        if not self._object:
+            uuid = self.kwargs.get(self.lookup_field)
+            with get_documenten_client(self.zgw_group.drc_service) as client:
+                self._object = client.get_item_by_uuid(uuid)
+        return self._object
+
+    def get_paginated_queryset(self, params: dict) -> DocumentsPaginatedResponse:
+        with (
+            get_documenten_client(self.zgw_group.drc_service) as doc_client,
+            get_oio_client(self.zgw_group.drc_service) as oio_client,
+        ):
+            return doc_client.get_unlinked_documents_by_iot(
+                self.iot_url, oio_client, params
+            )
+
+    @extend_schema(
+        "onbekend_document_download",
+        summary="onbekendDocumentsDownload",
+        description="Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT (onbekend/niet gekoppeld).",
+        parameters=[SERVICE_PARAM, INFORMATIEOBJECTTYPEN_IOT_UUID_PARAM, DOCUMENT_PARAM],
+        responses={
+            (status.HTTP_200_OK, "application/octet-stream"): OpenApiResponse(
+                description="De binaire bestandsinhoud",
+                response=OpenApiTypes.BINARY,
+            )
+        },
+    )
+    @action(methods=["get"], detail=True, name="onbekend_document_download")
+    def download(self, request: Request, *args, **kwargs):
+        obj = self.get_object()
+        with get_documenten_client(self.zgw_group.drc_service) as client:
+            return client.download_document(obj)

--- a/src/opendms/frontend/.storybook/public/mockServiceWorker.js
+++ b/src/opendms/frontend/.storybook/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.10'
+const PACKAGE_VERSION = '2.13.3'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/opendms/frontend/src/components/service-select/service-select.tsx
+++ b/src/opendms/frontend/src/components/service-select/service-select.tsx
@@ -19,7 +19,7 @@ export function ServiceSelect() {
   const getServiceOptions: LoadOptionsFn = async (
     search,
   ): Promise<Option[]> => {
-    const { data } = await apiClient.GET("/api/v1/services", {
+    const { data } = await apiClient.GET("/services", {
       params: {
         query: {
           search,

--- a/src/opendms/frontend/src/components/zaaktype-select/zaaktype-select.tsx
+++ b/src/opendms/frontend/src/components/zaaktype-select/zaaktype-select.tsx
@@ -1,6 +1,6 @@
 import { type LoadOptionsFn, type Option, Select } from "@maykin-ui/admin-ui";
 import { invariant } from "@maykin-ui/client-common";
-import { useNavigate, useParams } from "react-router";
+import { useMatch, useNavigate, useParams } from "react-router";
 import { apiClient } from "~/lib";
 
 /**
@@ -15,6 +15,8 @@ export function ZaaktypeSelect() {
     serviceSlug: string | undefined;
     zaaktypeUuid: string | undefined;
   };
+
+  const ONBEKEND_VALUE = "onbekend";
 
   /**
    * Fetches the service options from the backend (client-side)
@@ -38,22 +40,32 @@ export function ZaaktypeSelect() {
       },
     );
 
-    return (
+    const zaaktypeOptions: Option[] =
       data?.results.map(({ identificatie, uuid }) => ({
         label: identificatie,
         value: uuid,
-      })) || []
-    );
+      })) || [];
+
+    return [...zaaktypeOptions, { label: "Onbekend", value: ONBEKEND_VALUE }];
   };
 
   /**
-   * Routes to `:zaaktypeUuid`
+   * Routes to `:zaaktypeUuid` or `onbekend`
    * @param value
    */
   const setSelectedZaaktype = (value: string) => {
     invariant(serviceSlug, "Can't select zaaktypeUuid without serviceSlug!");
-    navigate(`/${serviceSlug}/${value}`);
+    if (value === ONBEKEND_VALUE) {
+      navigate(`/${serviceSlug}/onbekend`);
+    } else {
+      navigate(`/${serviceSlug}/${value}`);
+    }
   };
+
+  const onbekendMatch =
+    useMatch("/:serviceSlug/onbekend") ||
+    useMatch("/:serviceSlug/onbekend/:iotUuid");
+  const currentValue = onbekendMatch ? ONBEKEND_VALUE : zaaktypeUuid;
 
   return (
     serviceSlug && ( // TODO: https://github.com/maykinmedia/admin-ui/issues/301
@@ -63,7 +75,7 @@ export function ZaaktypeSelect() {
         options={getZaaktypeOptions}
         placeholder="Selecteer zaaktype"
         placeholderSearch="Zoeken"
-        value={zaaktypeUuid}
+        value={currentValue}
         variant="secondary"
         onChange={({ target }) => setSelectedZaaktype(target.value)}
       />

--- a/src/opendms/frontend/src/components/zaaktype-select/zaaktype-select.tsx
+++ b/src/opendms/frontend/src/components/zaaktype-select/zaaktype-select.tsx
@@ -29,7 +29,7 @@ export function ZaaktypeSelect() {
     if (!serviceSlug) return [];
 
     const { data } = await apiClient.GET(
-      `/api/v1/services/{serviceSlug}/zaaktypen`,
+      `/services/{serviceSlug}/zaaktypen`,
       {
         params: {
           path: { serviceSlug },

--- a/src/opendms/frontend/src/components/zaaktype-select/zaaktype-select.tsx
+++ b/src/opendms/frontend/src/components/zaaktype-select/zaaktype-select.tsx
@@ -62,10 +62,10 @@ export function ZaaktypeSelect() {
     }
   };
 
-  const onbekendMatch =
-    useMatch("/:serviceSlug/onbekend") ||
-    useMatch("/:serviceSlug/onbekend/:iotUuid");
-  const currentValue = onbekendMatch ? ONBEKEND_VALUE : zaaktypeUuid;
+  const onbekendIndexMatch = useMatch("/:serviceSlug/onbekend");
+  const onbekendUuidMatch = useMatch("/:serviceSlug/onbekend/:iotUuid");
+  const currentValue =
+    onbekendIndexMatch || onbekendUuidMatch ? ONBEKEND_VALUE : zaaktypeUuid;
 
   return (
     serviceSlug && ( // TODO: https://github.com/maykinmedia/admin-ui/issues/301

--- a/src/opendms/frontend/src/lib/api.ts
+++ b/src/opendms/frontend/src/lib/api.ts
@@ -54,6 +54,7 @@ const csrfClientMiddleware: Middleware = {
  * and adheres to the defined paths structure for endpoint typing and safety.
  */
 export const apiClient = createClient<paths>({
+  baseUrl: "/api/v1",
   fetch: (input: Request) =>
     fetch(input, {
       credentials: "include",

--- a/src/opendms/frontend/src/middleware/auth.ts
+++ b/src/opendms/frontend/src/middleware/auth.ts
@@ -11,7 +11,7 @@ export const authRouterMiddleware: MiddlewareFunction<unknown> = async (
   { context },
   next,
 ) => {
-  const { data: whoAmI } = await apiClient.GET("/api/v1/accounts/whoami");
+  const { data: whoAmI } = await apiClient.GET("/accounts/whoami");
 
   if (!whoAmI?.isAuthenticated) {
     throw redirect("/login");

--- a/src/opendms/frontend/src/root.tsx
+++ b/src/opendms/frontend/src/root.tsx
@@ -52,7 +52,7 @@ export const AuthenticatedLayout = () => {
   };
 
   const handleLogout = async () => {
-    await apiClient.GET("/api/v1/accounts/logout");
+    await apiClient.GET("/accounts/logout");
     navigate("/login");
   };
 
@@ -61,7 +61,7 @@ export const AuthenticatedLayout = () => {
     { signal }: { signal: AbortSignal },
   ): Promise<SearchResult[]> => {
     if (!query.trim()) return [];
-    const { data } = await apiClient.POST("/api/v1/search", {
+    const { data } = await apiClient.POST("/search", {
       body: { query, page: 1, pageSize: 10, sort: "relevance" },
       signal,
     });

--- a/src/opendms/frontend/src/routes.ts
+++ b/src/opendms/frontend/src/routes.ts
@@ -3,9 +3,13 @@ import { authenticatedRootLoader } from "~/routes/authenticated-root.loader.ts";
 import { documentsListLoader } from "~/routes/documents-list";
 import { DocumentsList } from "~/routes/documents-list/documents-list.tsx";
 import {
+  InformatieObjectTypenList,
   Login,
+  OnbekendDocumentsList,
   ZakenList,
+  informatieobjecttypenListLoader,
   loginAction,
+  onbekendDocumentsListLoader,
   zakenListLoader,
 } from "~/routes/index.ts";
 import { loginLoader } from "~/routes/login/login.loader.ts";
@@ -32,6 +36,21 @@ export const routes: [RouteObject, ...RouteObject[]] = [
     loader: authenticatedRootLoader,
     shouldRevalidate: () => true,
     children: [
+      {
+        path: ":serviceSlug/onbekend",
+        children: [
+          {
+            index: true,
+            Component: InformatieObjectTypenList,
+            loader: informatieobjecttypenListLoader,
+          },
+          {
+            path: ":iotUuid",
+            Component: OnbekendDocumentsList,
+            loader: onbekendDocumentsListLoader,
+          },
+        ],
+      },
       {
         path: ":serviceSlug?/:zaaktypeUuid?/:zaakYear?",
         children: [

--- a/src/opendms/frontend/src/routes/authenticated-root.loader.ts
+++ b/src/opendms/frontend/src/routes/authenticated-root.loader.ts
@@ -20,7 +20,7 @@ export async function authenticatedRootLoader({
   const { serviceSlug, zaaktypeUuid } = params;
   if (!serviceSlug || !zaaktypeUuid) return { zaaktype: undefined };
   const { data: zaaktype } = await apiClient.GET(
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypeUuid}",
+    "/services/{serviceSlug}/zaaktypen/{zaaktypeUuid}",
     {
       params: {
         path: {

--- a/src/opendms/frontend/src/routes/documents-list/documents-list.loader.ts
+++ b/src/opendms/frontend/src/routes/documents-list/documents-list.loader.ts
@@ -19,7 +19,7 @@ export async function documentsListLoader({
   const page = Number(urlSearchParams.get("page")) || undefined;
 
   const { data: zaak } = await apiClient.GET(
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zaakUuid}",
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zaakUuid}",
     {
       params: {
         path: {
@@ -61,7 +61,7 @@ export async function fetchDocuments(
   signal?: AbortSignal,
 ) {
   return await apiClient.GET(
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents",
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents",
     {
       params: {
         path: {

--- a/src/opendms/frontend/src/routes/index.ts
+++ b/src/opendms/frontend/src/routes/index.ts
@@ -1,3 +1,5 @@
 export * from "./authenticated-root.loader";
+export * from "./informatieobjecttypen-list";
 export * from "./login";
+export * from "./onbekend-documents-list";
 export * from "./zaken-list";

--- a/src/opendms/frontend/src/routes/informatieobjecttypen-list/index.ts
+++ b/src/opendms/frontend/src/routes/informatieobjecttypen-list/index.ts
@@ -1,0 +1,2 @@
+export * from "./informatieobjecttypen-list";
+export * from "./informatieobjecttypen-list.loader";

--- a/src/opendms/frontend/src/routes/informatieobjecttypen-list/informatieobjecttypen-list.loader.ts
+++ b/src/opendms/frontend/src/routes/informatieobjecttypen-list/informatieobjecttypen-list.loader.ts
@@ -11,8 +11,7 @@ export async function informatieobjecttypenListLoader({
   if (!params.serviceSlug) return null;
 
   const { data } = await apiClient.GET(
-    // @ts-expect-error - API not ready
-    "/api/v1/services/{serviceSlug}/informatieobjecttypen",
+    "/services/{serviceSlug}/informatieobjecttypen",
     {
       params: {
         path: { serviceSlug: params.serviceSlug },

--- a/src/opendms/frontend/src/routes/informatieobjecttypen-list/informatieobjecttypen-list.loader.ts
+++ b/src/opendms/frontend/src/routes/informatieobjecttypen-list/informatieobjecttypen-list.loader.ts
@@ -1,0 +1,24 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { apiClient } from "~/lib";
+import type { InformatieObjectType } from "~/types";
+
+export async function informatieobjecttypenListLoader({
+  params,
+}: LoaderFunctionArgs): Promise<{
+  count: number;
+  results: InformatieObjectType[];
+} | null> {
+  if (!params.serviceSlug) return null;
+
+  const { data } = await apiClient.GET(
+    // @ts-expect-error - API not ready
+    "/api/v1/services/{serviceSlug}/informatieobjecttypen",
+    {
+      params: {
+        path: { serviceSlug: params.serviceSlug },
+      },
+    },
+  );
+
+  return (data as unknown as { count: number; results: InformatieObjectType[] }) ?? null;
+}

--- a/src/opendms/frontend/src/routes/informatieobjecttypen-list/informatieobjecttypen-list.tsx
+++ b/src/opendms/frontend/src/routes/informatieobjecttypen-list/informatieobjecttypen-list.tsx
@@ -1,0 +1,53 @@
+import {
+  type ItemGridItemProps,
+  ItemGridTemplate,
+  Outline,
+  P,
+} from "@maykin-ui/admin-ui";
+import { invariant } from "@maykin-ui/client-common";
+import { useMemo } from "react";
+import { useLoaderData, useNavigate, useParams } from "react-router";
+import type { InformatieObjectType } from "~/types";
+
+import type { informatieobjecttypenListLoader } from "./informatieobjecttypen-list.loader";
+
+export function InformatieObjectTypenList() {
+  const data = useLoaderData<typeof informatieobjecttypenListLoader>();
+  const navigate = useNavigate();
+
+  // TODO: Validation. See issue gh-#42
+  const { serviceSlug } = useParams() as {
+    serviceSlug: string | undefined;
+  };
+
+  const items = useMemo<ItemGridItemProps[]>(
+    () =>
+      data?.results?.map((iot: InformatieObjectType) => ({
+        id: String(iot.uuid),
+        title: iot.omschrijving,
+        icon: <Outline.FolderIcon />,
+        actions: [
+          {
+            as: "button" as const,
+            "aria-label": iot.omschrijving,
+            onClick: () => {
+              invariant(serviceSlug);
+              navigate(`/${serviceSlug}/onbekend/${iot.uuid}`);
+            },
+          },
+        ],
+      })) ?? [],
+    [data?.results, serviceSlug, navigate],
+  );
+
+  if (!data) return null;
+
+  return (
+    <ItemGridTemplate
+      title="Onbekend"
+      itemGridProps={{ direction: "h", ellipsis: true, items }}
+    >
+      <P>{data.count} documenttypen</P>
+    </ItemGridTemplate>
+  );
+}

--- a/src/opendms/frontend/src/routes/login/login.actions.ts
+++ b/src/opendms/frontend/src/routes/login/login.actions.ts
@@ -13,7 +13,7 @@ export async function loginAction({ request }: ActionFunctionArgs) {
   const username = formData.get("username") || "";
   const password = formData.get("password") || "";
 
-  const { error } = await apiClient.POST("/api/v1/accounts/login", {
+  const { error } = await apiClient.POST("/accounts/login", {
     body: {
       username: username.toString(),
       password: password.toString(),

--- a/src/opendms/frontend/src/routes/login/login.loader.ts
+++ b/src/opendms/frontend/src/routes/login/login.loader.ts
@@ -4,5 +4,5 @@ import { apiClient } from "~/lib";
  * Makes sure the CSRF-cookie is available.
  */
 export async function loginLoader() {
-  await apiClient.GET("/api/v1/accounts/whoami");
+  await apiClient.GET("/accounts/whoami");
 }

--- a/src/opendms/frontend/src/routes/onbekend-documents-list/index.ts
+++ b/src/opendms/frontend/src/routes/onbekend-documents-list/index.ts
@@ -1,0 +1,2 @@
+export * from "./onbekend-documents-list";
+export * from "./onbekend-documents-list.loader";

--- a/src/opendms/frontend/src/routes/onbekend-documents-list/onbekend-documents-list.loader.ts
+++ b/src/opendms/frontend/src/routes/onbekend-documents-list/onbekend-documents-list.loader.ts
@@ -12,8 +12,7 @@ export async function onbekendDocumentsListLoader({
   const page = Number(url.searchParams.get("page")) || undefined;
 
   const { data } = await apiClient.GET(
-    // @ts-expect-error - API not ready
-    "/api/v1/services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents",
+    "/services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents",
     {
       params: {
         path: {

--- a/src/opendms/frontend/src/routes/onbekend-documents-list/onbekend-documents-list.loader.ts
+++ b/src/opendms/frontend/src/routes/onbekend-documents-list/onbekend-documents-list.loader.ts
@@ -1,0 +1,32 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { apiClient } from "~/lib";
+import type { Document } from "~/types";
+
+export async function onbekendDocumentsListLoader({
+  params,
+  request,
+}: LoaderFunctionArgs) {
+  if (!params.serviceSlug || !params.iotUuid) return null;
+
+  const url = new URL(request.url);
+  const page = Number(url.searchParams.get("page")) || undefined;
+
+  const { data } = await apiClient.GET(
+    // @ts-expect-error - API not ready
+    "/api/v1/services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents",
+    {
+      params: {
+        path: {
+          serviceSlug: params.serviceSlug,
+          informatieobjecttypenIotUuid: params.iotUuid,
+        },
+        query: {
+          page: page,
+          pageSize: 20,
+        },
+      },
+    },
+  );
+
+  return (data as unknown as { count: number; results: Document[] }) ?? null;
+}

--- a/src/opendms/frontend/src/routes/onbekend-documents-list/onbekend-documents-list.tsx
+++ b/src/opendms/frontend/src/routes/onbekend-documents-list/onbekend-documents-list.tsx
@@ -1,0 +1,64 @@
+import {
+  type ItemGridItemProps,
+  ItemGridTemplate,
+  Outline,
+  P,
+} from "@maykin-ui/admin-ui";
+import { useMemo } from "react";
+import {
+  useLoaderData,
+  useParams,
+  useSearchParams,
+} from "react-router";
+import { getPageFromSearchParams } from "~/lib";
+import type { Document } from "~/types";
+
+import type { onbekendDocumentsListLoader } from "./onbekend-documents-list.loader";
+
+export function OnbekendDocumentsList() {
+  const data = useLoaderData<typeof onbekendDocumentsListLoader>();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // TODO: Validation. See issue gh-#42
+  const { serviceSlug, iotUuid } = useParams() as {
+    serviceSlug: string | undefined;
+    iotUuid: string | undefined;
+  };
+
+  const items = useMemo<ItemGridItemProps[]>(
+    () =>
+      data?.results?.map((doc: Document) => ({
+        id: doc.uuid,
+        title: doc.titel,
+        icon: <Outline.DocumentIcon />,
+        informationLines: [doc.identificatie].filter(Boolean),
+        actions: [
+          {
+            as: "a" as const,
+            children: <Outline.ArrowDownOnSquareIcon />,
+            download: true,
+            href: `/api/v1/services/${serviceSlug}/informatieobjecttypen/${iotUuid}/documents/${doc.uuid}/download`,
+            title: "Bestand downloaden",
+          },
+        ],
+      })) ?? [],
+    [data?.results, serviceSlug, iotUuid],
+  );
+
+  if (!data) return null;
+
+  return (
+    <ItemGridTemplate
+      title="Onbekend"
+      itemGridProps={{ direction: "v", ellipsis: true, items }}
+      paginatorProps={{
+        count: data.count,
+        page: getPageFromSearchParams(searchParams),
+        pageSize: 20,
+        onPageChange: (page) => setSearchParams({ page: page.toString() }),
+      }}
+    >
+      <P>{data.count} documenten</P>
+    </ItemGridTemplate>
+  );
+}

--- a/src/opendms/frontend/src/routes/zaken-list/zaken-list.loader.ts
+++ b/src/opendms/frontend/src/routes/zaken-list/zaken-list.loader.ts
@@ -26,7 +26,7 @@ export async function zakenListLoader({
 
   const { data } = await apiClient.GET(
     // @ts-expect-error - API not ready
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypeUuid}/zaken",
+    "/services/{serviceSlug}/zaaktypen/{zaaktypeUuid}/zaken",
     {
       params: {
         path: params,

--- a/src/opendms/frontend/src/types/index.d.ts
+++ b/src/opendms/frontend/src/types/index.d.ts
@@ -9,6 +9,7 @@ export type Document = components["schemas"]["Document"];
 
 export type ZaakType = components["schemas"]["ZaakType"];
 export type Zaak = components["schemas"]["Zaak"];
+export type InformatieObjectType = components["schemas"]["InformatieObjectType"];
 
 export type Fout = components["schemas"]["Fout"];
 export type ValidatieFout = components["schemas"]["ValidatieFout"];

--- a/src/opendms/frontend/src/types/schema.d.ts
+++ b/src/opendms/frontend/src/types/schema.d.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    "/api/v1/accounts/login": {
+    "/accounts/login": {
         parameters: {
             query?: never;
             header?: never;
@@ -17,14 +17,14 @@ export interface paths {
          * login
          * @description Authenticates the user, returns whoami details on successful login.
          */
-        post: operations["apiV1AccountsLoginCreate"];
+        post: operations["accountsLoginCreate"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/v1/accounts/logout": {
+    "/accounts/logout": {
         parameters: {
             query?: never;
             header?: never;
@@ -35,7 +35,7 @@ export interface paths {
          * logout
          * @description Remove the authenticated user's ID from the request and flush their session data.
          */
-        get: operations["apiV1AccountsLogoutRetrieve"];
+        get: operations["accountsLogoutRetrieve"];
         put?: never;
         post?: never;
         delete?: never;
@@ -44,7 +44,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/accounts/whoami": {
+    "/accounts/whoami": {
         parameters: {
             query?: never;
             header?: never;
@@ -55,7 +55,7 @@ export interface paths {
          * whoami
          * @description Returns the current logged in user.
          */
-        get: operations["apiV1AccountsWhoamiRetrieve"];
+        get: operations["accountsWhoamiRetrieve"];
         put?: never;
         post?: never;
         delete?: never;
@@ -64,7 +64,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/search": {
+    "/search": {
         parameters: {
             query?: never;
             header?: never;
@@ -74,7 +74,7 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Search
+         * Zoeken
          * @description Search the document records.
          */
         post: operations["search"];
@@ -84,14 +84,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services": {
+    "/services": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations["apiV1ServicesList"];
+        get: operations["servicesList"];
         put?: never;
         post?: never;
         delete?: never;
@@ -100,7 +100,109 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen": {
+    "/services/{serviceSlug}/informatieobjecttypen": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * informatieobjecttypenList
+         * @description Exposes InformatieObjectTypen from /services/<zgw-service>/informatieobjecttypen
+         */
+        get: operations["servicesInformatieobjecttypenList"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * onbekendDocumentsList
+         * @description Exposes Documents not linked to any Zaak, grouped by InformatieObjectType.
+         *     Route: /services/<serviceSlug>/informatieobjecttypen/<iotUuid>/documents
+         */
+        get: operations["servicesInformatieobjecttypenDocumentsList"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents/{documentUuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * onbekendDocumentsRetrieve
+         * @description Exposes Documents not linked to any Zaak, grouped by InformatieObjectType.
+         *     Route: /services/<serviceSlug>/informatieobjecttypen/<iotUuid>/documents
+         */
+        get: operations["servicesInformatieobjecttypenDocumentsRetrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/services/{serviceSlug}/informatieobjecttypen/{informatieobjecttypenIotUuid}/documents/{documentUuid}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * onbekendDocumentsDownload
+         * @description Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT (onbekend/niet gekoppeld).
+         */
+        get: operations["onbekendDocumentDownload"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/services/{serviceSlug}/informatieobjecttypen/{iotUuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * informatieobjecttypenRetrieve
+         * @description Exposes InformatieObjectTypen from /services/<zgw-service>/informatieobjecttypen
+         */
+        get: operations["servicesInformatieobjecttypenRetrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/services/{serviceSlug}/zaaktypen": {
         parameters: {
             query?: never;
             header?: never;
@@ -111,7 +213,7 @@ export interface paths {
          * zaaktypenList
          * @description Exposes Zaaktypen from /services/<zgw-service>/zaaktypen
          */
-        get: operations["apiV1ServicesZaaktypenList"];
+        get: operations["servicesZaaktypenList"];
         put?: never;
         post?: never;
         delete?: never;
@@ -120,7 +222,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypeUuid}": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypeUuid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -131,7 +233,7 @@ export interface paths {
          * zaaktypenRetrieve
          * @description Exposes Zaaktypen from /services/<zgw-service>/zaaktypen
          */
-        get: operations["apiV1ServicesZaaktypenRetrieve"];
+        get: operations["servicesZaaktypenRetrieve"];
         put?: never;
         post?: never;
         delete?: never;
@@ -140,7 +242,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken": {
         parameters: {
             query?: never;
             header?: never;
@@ -151,7 +253,7 @@ export interface paths {
          * zakenList
          * @description Exposes Zaak from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken
          */
-        get: operations["apiV1ServicesZaaktypenZakenList"];
+        get: operations["servicesZaaktypenZakenList"];
         put?: never;
         post?: never;
         delete?: never;
@@ -160,7 +262,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zaakUuid}": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zaakUuid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -171,7 +273,7 @@ export interface paths {
          * zakenRetrieve
          * @description Exposes Zaak from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken
          */
-        get: operations["apiV1ServicesZaaktypenZakenRetrieve"];
+        get: operations["servicesZaaktypenZakenRetrieve"];
         put?: never;
         post?: never;
         delete?: never;
@@ -180,7 +282,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents": {
         parameters: {
             query?: never;
             header?: never;
@@ -191,7 +293,7 @@ export interface paths {
          * documentsList
          * @description Exposes Documents from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken/<zaak>/documents
          */
-        get: operations["apiV1ServicesZaaktypenZakenDocumentsList"];
+        get: operations["servicesZaaktypenZakenDocumentsList"];
         put?: never;
         post?: never;
         delete?: never;
@@ -200,7 +302,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -211,7 +313,7 @@ export interface paths {
          * documentsRetrieve
          * @description Exposes Documents from /services/<zgw-service>/zaaktypen/<zaaktype>/zaken/<zaak>/documents
          */
-        get: operations["apiV1ServicesZaaktypenZakenDocumentsRetrieve"];
+        get: operations["servicesZaaktypenZakenDocumentsRetrieve"];
         put?: never;
         post?: never;
         delete?: never;
@@ -220,7 +322,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/download": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/download": {
         parameters: {
             query?: never;
             header?: never;
@@ -240,7 +342,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/edit": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/edit": {
         parameters: {
             query?: never;
             header?: never;
@@ -260,7 +362,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/upload": {
+    "/services/{serviceSlug}/zaaktypen/{zaaktypenZaaktypeUuid}/zaken/{zakenZaakUuid}/documents/{documentUuid}/upload": {
         parameters: {
             query?: never;
             header?: never;
@@ -280,56 +382,16 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/services/{slug}": {
+    "/services/{slug}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations["apiV1ServicesRetrieve"];
+        get: operations["servicesRetrieve"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/oidc/callback/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Microsoft authentication callback
-         * @description Callback endpoint voor Microsoft OAuth authenticatie.
-         */
-        get: operations["oidcCallbackRetrieve"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/webhook": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Webhook callback
-         * @description Endpoint webhook che riceve notifiche dal backend document_edit.
-         */
-        post: operations["webhookCreate"];
         delete?: never;
         options?: never;
         head?: never;
@@ -341,7 +403,9 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         Auth: {
+            /** Gebruikersnaam */
             username: string;
+            /** Wachtwoord */
             password: string;
         };
         Document: {
@@ -528,10 +592,45 @@ export interface components {
             /** @description URI met referentie naar dit specifiek voorkomen van de fout. Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld. */
             instance: string;
         };
+        InformatieObjectType: {
+            /** @description Unieke resource identifier (UUID4) */
+            uuid: string;
+            /**
+             * Format: uri
+             * @description URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object.
+             */
+            url: string;
+            /**
+             * Format: uri
+             * @description URL-referentie naar de CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.
+             */
+            catalogus: string;
+            /** @description Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE. */
+            omschrijving: string;
+            /** @description Aanduiding van de mate waarin informatieobjecten van dit type voor de openbaarheid bestemd zijn. */
+            vertrouwelijkheidaanduiding?: string | null;
+            /**
+             * Format: date
+             * @description De datum waarop het is ontstaan.
+             */
+            beginGeldigheid?: string | null;
+            /**
+             * Format: date
+             * @description De datum waarop het is opgeheven.
+             */
+            eindeGeldigheid?: string | null;
+            /** @description Geeft aan of het object een concept betreft. */
+            concept: boolean;
+        };
         PaginatedDocumentList: {
             /** @example 123 */
             count: number;
             results: components["schemas"]["Document"][];
+        };
+        PaginatedInformatieObjectTypeList: {
+            /** @example 123 */
+            count: number;
+            results: components["schemas"]["InformatieObjectType"][];
         };
         PaginatedServiceList: {
             /** @example 123 */
@@ -635,12 +734,17 @@ export interface components {
         User: {
             /** ID */
             readonly pk: number;
-            /** @description Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only. */
+            /**
+             * Gebruikersnaam
+             * @description Vereist. 150 tekens of minder. Alleen letters, cijfers en de tekens @/,/+/-/_ zijn toegestaan.
+             */
             username: string;
+            /** Voornaam */
             firstName?: string;
+            /** Achternaam */
             lastName?: string;
             /**
-             * Email address
+             * E-mailadres
              * Format: email
              */
             email?: string;
@@ -739,7 +843,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    apiV1AccountsLoginCreate: {
+    accountsLoginCreate: {
         parameters: {
             query?: never;
             header?: never;
@@ -784,7 +888,7 @@ export interface operations {
             };
         };
     };
-    apiV1AccountsLogoutRetrieve: {
+    accountsLogoutRetrieve: {
         parameters: {
             query?: never;
             header?: never;
@@ -804,7 +908,7 @@ export interface operations {
             };
         };
     };
-    apiV1AccountsWhoamiRetrieve: {
+    accountsWhoamiRetrieve: {
         parameters: {
             query?: never;
             header?: never;
@@ -850,10 +954,10 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesList: {
+    servicesList: {
         parameters: {
             query?: {
-                /** @description A page number within the paginated result set. */
+                /** @description Een pagina binnen de gepagineerde set resultaten. */
                 page?: number;
                 /** @description Het aantal resultaten terug te geven per pagina. (default: 100, maximum: 500). */
                 pageSize?: number;
@@ -878,10 +982,142 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesZaaktypenList: {
+    servicesInformatieobjecttypenList: {
         parameters: {
             query?: {
-                /** @description A page number within the paginated result set. */
+                /** @description Een pagina binnen de gepagineerde set resultaten. */
+                page?: number;
+                /** @description Het aantal resultaten terug te geven per pagina. (default: 100, maximum: 500). */
+                pageSize?: number;
+            };
+            header?: never;
+            path: {
+                serviceSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
+                    "API-version"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedInformatieObjectTypeList"];
+                };
+            };
+        };
+    };
+    servicesInformatieobjecttypenDocumentsList: {
+        parameters: {
+            query?: {
+                /** @description Een pagina binnen de gepagineerde set resultaten. */
+                page?: number;
+                /** @description Het aantal resultaten terug te geven per pagina. (default: 100, maximum: 500). */
+                pageSize?: number;
+            };
+            header?: never;
+            path: {
+                informatieobjecttypenIotUuid: string;
+                serviceSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
+                    "API-version"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedDocumentList"];
+                };
+            };
+        };
+    };
+    servicesInformatieobjecttypenDocumentsRetrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                documentUuid: string;
+                informatieobjecttypenIotUuid: string;
+                serviceSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
+                    "API-version"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Document"];
+                };
+            };
+        };
+    };
+    onbekendDocumentDownload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                documentUuid: string;
+                informatieobjecttypenIotUuid: string;
+                serviceSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description De binaire bestandsinhoud */
+            200: {
+                headers: {
+                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
+                    "API-version"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/octet-stream": string;
+                };
+            };
+        };
+    };
+    servicesInformatieobjecttypenRetrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                iotUuid: string;
+                serviceSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
+                    "API-version"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InformatieObjectType"];
+                };
+            };
+        };
+    };
+    servicesZaaktypenList: {
+        parameters: {
+            query?: {
+                /** @description Een pagina binnen de gepagineerde set resultaten. */
                 page?: number;
                 /** @description Het aantal resultaten terug te geven per pagina. (default: 100, maximum: 500). */
                 pageSize?: number;
@@ -908,7 +1144,7 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesZaaktypenRetrieve: {
+    servicesZaaktypenRetrieve: {
         parameters: {
             query?: never;
             header?: never;
@@ -932,14 +1168,14 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesZaaktypenZakenList: {
+    servicesZaaktypenZakenList: {
         parameters: {
             query?: {
                 /** @description De unieke identificatie van de ZAAK (bevat de identificatie de gegeven waarden (hoofdletterongevoelig)) */
                 identificatie__icontains?: string;
                 /** @description Een korte omschrijving van de ZAAK (bevat de omschrijving de gegeven waarden (hoofdletterongevoelig)) */
                 omschrijving?: string;
-                /** @description A page number within the paginated result set. */
+                /** @description Een pagina binnen de gepagineerde set resultaten. */
                 page?: number;
                 /** @description Het aantal resultaten terug te geven per pagina. (default: 100, maximum: 500). */
                 pageSize?: number;
@@ -967,7 +1203,7 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesZaaktypenZakenRetrieve: {
+    servicesZaaktypenZakenRetrieve: {
         parameters: {
             query?: never;
             header?: never;
@@ -992,10 +1228,10 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesZaaktypenZakenDocumentsList: {
+    servicesZaaktypenZakenDocumentsList: {
         parameters: {
             query?: {
-                /** @description A page number within the paginated result set. */
+                /** @description Een pagina binnen de gepagineerde set resultaten. */
                 page?: number;
                 /** @description Het aantal resultaten terug te geven per pagina. (default: 100, maximum: 500). */
                 pageSize?: number;
@@ -1022,7 +1258,7 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesZaaktypenZakenDocumentsRetrieve: {
+    servicesZaaktypenZakenDocumentsRetrieve: {
         parameters: {
             query?: never;
             header?: never;
@@ -1147,7 +1383,7 @@ export interface operations {
             };
         };
     };
-    apiV1ServicesRetrieve: {
+    servicesRetrieve: {
         parameters: {
             query?: never;
             header?: never;
@@ -1167,81 +1403,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Service"];
                 };
-            };
-        };
-    };
-    oidcCallbackRetrieve: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Redirect naar de oorspronkelijke URL na succesvolle authenticatie */
-            302: {
-                headers: {
-                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
-                    "API-version"?: string;
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Invalid callback of fout tijdens authenticatie */
-            400: {
-                headers: {
-                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
-                    "API-version"?: string;
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Authenticatie mislukt (geen access token) */
-            401: {
-                headers: {
-                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
-                    "API-version"?: string;
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    webhookCreate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
-            };
-        };
-        responses: {
-            /** @description Webhook verwerkt */
-            200: {
-                headers: {
-                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
-                    "API-version"?: string;
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": string;
-                };
-            };
-            /** @description Ongeldige payload */
-            400: {
-                headers: {
-                    /** @description Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1. */
-                    "API-version"?: string;
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };


### PR DESCRIPTION
Adds a new backend endpoint and frontend route to list and browse enkelvoudiginformatieobjecten that are not associated with any zaak, including support for filtering by informatieobjecttype.


